### PR TITLE
Use specific calls to std::find to appease clang

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -1046,14 +1046,14 @@ CHECK_RETURN astSwitchStatement *parser::parseSwitchStatement() {
                 // "It is a compile-time error to have two case label constant-expression of equal value"
                 if (value->type == astExpression::kIntConstant) {
                     const int val = IVAL(value);
-                    if (find(seenInts.begin(), seenInts.end(), val) != seenInts.end()) {
+                    if (std::find(seenInts.begin(), seenInts.end(), val) != seenInts.end()) {
                         fatal("duplicate case label `%d'", val);
                         return 0;
                     }
                     seenInts.push_back(val);
                 } else if (value->type == astExpression::kUIntConstant) {
                     const unsigned int val = UVAL(value);
-                    if (find(seenUInts.begin(), seenUInts.end(), val) != seenUInts.end()) {
+                    if (std::find(seenUInts.begin(), seenUInts.end(), val) != seenUInts.end()) {
                         fatal("duplicate case label `%u'", val);
                         return 0;
                     }


### PR DESCRIPTION
When compiling on OSX 10.11 (clang-703.0.29) the compiler complains that the call to `find` is ambiguous. I presume the call needed here is the one for `std::find`. Setting the namespace explicitly resolves the issue, tests pass.
