### PR TITLE
fixed multiple function parameters not separating by commas

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -553,8 +553,11 @@ static void printFunctionParameter(astFunctionParameter *parameter) {
 static void printFunction(astFunction *function) {
     printType(function->returnType);
     print(" %s(", function->name);
-    for (size_t i = 0; i < function->parameters.size(); i++)
+    for (size_t i = 0; i < function->parameters.size(); i++) {
         printFunctionParameter(function->parameters[i]);
+        if (i < function->parameters.size()-1)
+        	print(", ");
+    }
     print(")");
     if (function->isPrototype) {
         print(";\n");

--- a/tests/multiple_parameters.glsl
+++ b/tests/multiple_parameters.glsl
@@ -1,0 +1,3 @@
+vec4 test_func(float red, float green, float blue, float alpha) {
+	return vec4(red, green, blue, alpha);
+}

--- a/tests/multiple_parameters.test
+++ b/tests/multiple_parameters.test
@@ -1,0 +1,3 @@
+vec4 test_func(float red, float green, float blue, float alpha) {
+return vec4(red, green, blue, alpha);
+}


### PR DESCRIPTION
Fixed multiple function parameters not separating by commas and added a test for it.
Originally, a function definition such as

```glsl
vec4 test_func(float red, float green, float blue, float alpha) {
	return vec4(red, green, blue, alpha);
}
```

would output

```glsl
vec4 test_func(float redfloat greenfloat bluefloat alpha) {
return vec4(red, green, blue, alpha);
}
```

because the GLSL generator didn't check if separation was needed.